### PR TITLE
Fix duplicate branch names

### DIFF
--- a/BSM3G_TNT_Maker/src/TauSelector.cc
+++ b/BSM3G_TNT_Maker/src/TauSelector.cc
@@ -316,7 +316,7 @@ void TauSelector::SetBranches(){
   // Iso MVA with Delta Beta correction DR = 0.3
   AddBranch(&Tau_byVLooseIsolationMVArun2v1DBdR03oldDMwLT,      "Tau_byVLooseIsolationMVArun2v1DBdR03oldDMwLT");
   AddBranch(&Tau_byLooseIsolationMVArun2v1DBdR03oldDMwLT,       "Tau_byLooseIsolationMVArun2v1DBdR03oldDMwLT");
-  AddBranch(&Tau_byMediumIsolationMVArun2v1DBdR03oldDMwLT,      "Tau_byTightIsolationMVArun2v1DBdR03oldDMwLT");
+  AddBranch(&Tau_byMediumIsolationMVArun2v1DBdR03oldDMwLT,      "Tau_byMediumIsolationMVArun2v1DBdR03oldDMwLT");
   AddBranch(&Tau_byTightIsolationMVArun2v1DBdR03oldDMwLT,       "Tau_byTightIsolationMVArun2v1DBdR03oldDMwLT");
   AddBranch(&Tau_byVTightIsolationMVArun2v1DBdR03oldDMwLT,      "Tau_byVTightIsolationMVArun2v1DBdR03oldDMwLT");
   


### PR DESCRIPTION
Not sure why ROOT doesn't barf on this, but the
tuples end up having two branches named the same thing